### PR TITLE
feat(argument): allow optional arguments

### DIFF
--- a/base/arguments.py
+++ b/base/arguments.py
@@ -3,16 +3,19 @@ from abc import ABC
 
 class BaseArgument(ABC):
 
-    def __init__(self, options=None):
+    def __init__(self, options=None, required=True):
         if options is None:
             options = []
 
         self._data = None
         self.options = options
+        self.required = required
         self.has_validated = False
 
     def __len__(self):
-        return 1 + len(self.options)
+        if self.required:
+            return 1 + len(self.options)
+        return 0
 
     def _parse(self, user_input, options=None):
         pass

--- a/base/command.py
+++ b/base/command.py
@@ -22,12 +22,13 @@ class BaseCommand(ABC):
 
         return length
 
-    @staticmethod
-    def _check_input_length(arguments):
+    def _check_input_length(self, arguments):
         length = 1
-        for argument in arguments:
-            if argument[0] != '-':
-                length += 1
+
+        for index, argument in zip(range(len(arguments)), arguments):
+            if self.arguments[index].required:
+                if argument[0] != '-':
+                    length += 1
 
         return length
 

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -5,9 +5,13 @@ from base.arguments import IntArgument
 class PingCommand(BaseCommand):
 
     command = 'ping'
-    arguments = [IntArgument()]
+    arguments = [IntArgument(required=False)]
 
     def run(self):
-        times = self.arguments[0].data
-        for counter in range(1, times + 1):
-            self.log(f'{counter}) Pong!', prefix=False)
+        if self.arguments[0].has_validated:
+            times = self.arguments[0].data
+
+            for counter in range(1, times + 1):
+                self.log(f'{counter}) Pong!', prefix=False)
+        else:
+            self.log('Pong!', prefix=False)


### PR DESCRIPTION
Every argument accepts `required` parameter specifying if the command works without it. A sample
usage is available in `ping` command.

BREAKING CHANGE: - Check data has been validated before accessing it if the argument is marked
`required=False`

fix #24