### PR TITLE
:feat: Implement cat, cat-at with -w tag, fmap command

### DIFF
--- a/base/terminal.py
+++ b/base/terminal.py
@@ -4,7 +4,7 @@ from db.dao.session_dao import SessionDao
 from db.dao.file_dao import FileDao
 
 from db.models.session import Session
-from db.base import sector_size, total_size
+from db.base import SECTOR_SIZE, TOTAL_SIZE
 
 
 class BaseTerminal:
@@ -100,7 +100,7 @@ class BaseTerminal:
         if latest_session is None:
             self.log('Welcome to Distributed Finder!', prefix=False)
             SectorDao.create_sectors_division(
-                total_size(), sector_size())
+                TOTAL_SIZE, SECTOR_SIZE)
 
         else:
             self.log(latest_session, prefix=False)

--- a/commands/cat.py
+++ b/commands/cat.py
@@ -10,6 +10,8 @@ class CatCommand(BaseCommand):
     options = [StringOption('-w')]
 
     def read_From_file(self, file):
+        if file.is_empty:
+            raise ValueError('File is empty! No contents to show')
         file_sectors = file.sectors
         file_sectors.sort(key=lambda sector: sector.order)
         content = ''

--- a/commands/cat.py
+++ b/commands/cat.py
@@ -9,16 +9,6 @@ class CatCommand(BaseCommand):
     arguments = [StringArgument()]
     options = [StringOption('-w')]
 
-    def read_From_file(self, file):
-        if file.is_empty:
-            raise ValueError('File is empty! No contents to show')
-        file_sectors = file.sectors
-        file_sectors.sort(key=lambda sector: sector.order)
-        content = ''
-        for sector in file_sectors:
-            content += sector.data
-        return content
-
     def write_to_file(self, file, text):
         FileDao.remove_data_in_file(file)
         FileDao.insert_data_in_file(file, text)
@@ -32,5 +22,5 @@ class CatCommand(BaseCommand):
             text = self.get_input('Start Writing: ', prefix=False)
             self.write_to_file(file, text)
         else:
-            content = self.read_From_file(file)
+            content = FileDao.read_from_file(file)
             self.log(content, prefix=False)

--- a/commands/cat.py
+++ b/commands/cat.py
@@ -1,3 +1,4 @@
+from base.option import StringOption
 from base.command import BaseCommand
 from base.arguments import StringArgument
 from db.dao.file_dao import FileDao
@@ -6,11 +7,29 @@ from db.dao.file_dao import FileDao
 class CatCommand(BaseCommand):
     command = 'cat'
     arguments = [StringArgument()]
+    options = [StringOption('-w')]
+
+    def read_From_file(self, file):
+        file_sectors = file.sectors
+        file_sectors.sort(key=lambda sector: sector.order)
+        content = ''
+        for sector in file_sectors:
+            content += sector.data
+        return content
+
+    def write_to_file(self, file, text):
+        FileDao.remove_data_in_file(file)
+        FileDao.insert_data_in_file(file, text)
 
     def run(self):
         path = self.arguments[0].data
         file = self.context.parse(path, True)
-        self.log('WARNING: Data will be overwritten', prefix=False)
-        FileDao.remove_data_in_file(file)
-        text = self.get_input('Start Writing: ', prefix=False)
-        FileDao.insert_data_in_file(file, text)
+
+        if self.options[0].exists:
+            self.log('Warning: Data will be overwritten', prefix=False)
+            text = self.get_input('Start Writing: ', prefix=False)
+            self.write_to_file(file, text)
+
+        else:
+            content = self.read_From_file(file)
+            self.log(content, prefix=False)

--- a/commands/cat.py
+++ b/commands/cat.py
@@ -31,7 +31,6 @@ class CatCommand(BaseCommand):
             self.log('Warning: Data will be overwritten', prefix=False)
             text = self.get_input('Start Writing: ', prefix=False)
             self.write_to_file(file, text)
-
         else:
             content = self.read_From_file(file)
             self.log(content, prefix=False)

--- a/commands/cat_at.py
+++ b/commands/cat_at.py
@@ -55,37 +55,6 @@ class CatAtCommand(BaseCommand):
                     sector, data=sector.data,
                     order=end_order, file_id=sector.file_id)
 
-    def read_from_file(self, file, index, size):
-        file_size = FileDao.get_file_size(file)
-        if (index >= file_size):
-            raise ValueError(
-                'Index larger than content in file!')
-        # The sector from which data is to be read
-        start_read_sector_order = ceil((index + 1) / SECTOR_SIZE)
-        start_read_sector = [
-            sector for sector in
-            file.sectors if sector.order == start_read_sector_order][0]
-
-        # The remaining sectors to be read
-        end_sectors = [
-            sector for sector in file.sectors
-            if sector.order > start_read_sector_order
-        ]
-        # Sorting the remaining sectors by order
-        end_sectors.sort(key=lambda sector: sector.order)
-
-        # Read content of the sector from the specified index
-        start_read_sector_data = start_read_sector.data
-        start_index = index % SECTOR_SIZE
-        content = start_read_sector_data[start_index:]
-
-        # Read the content till the size specified
-        count = 0
-        while (size < len(content)) and (count < len(end_sectors)):
-            content += end_sectors[count].data
-            count += 1
-        return content[:size]
-
     def run(self):
         index = self.arguments[0].data
         path = self.arguments[1].data
@@ -97,5 +66,5 @@ class CatAtCommand(BaseCommand):
 
         else:
             size = int(self.get_input('Total size to read:', prefix=False))
-            content = self.read_from_file(file, index, size)
+            content = FileDao.read_from_file(file, index, size)
             self.log(content, prefix=False)

--- a/commands/cat_at.py
+++ b/commands/cat_at.py
@@ -1,22 +1,19 @@
+from base.option import StringOption
 from base.command import BaseCommand
 from base.arguments import IntArgument, StringArgument
 from db.dao.file_dao import FileDao
 from db.dao.sector_dao import SectorDao
-from db.base import sector_size
+from db.base import SECTOR_SIZE
 from math import ceil
 
 
 class CatAtCommand(BaseCommand):
     command = 'cat-at'
     arguments = [IntArgument(), StringArgument()]
+    options = [StringOption('-w')]
 
-    def run(self):
-        index = self.arguments[0].data
-        path = self.arguments[1].data
-        file = self.context.parse(path, True)
-
+    def write_to_file(self, file, index, text):
         file_size = FileDao.get_file_size(file)
-        text = self.get_input('Start Writing: ', prefix=False)
         # If index is larger than the end of the file
         # Append data at the end of the file
         if (index >= file_size):
@@ -24,7 +21,7 @@ class CatAtCommand(BaseCommand):
 
         else:
             # The sector in which data is to be manipulated
-            start_append_sector_order = ceil((index + 1) / sector_size())
+            start_append_sector_order = ceil((index + 1) / SECTOR_SIZE)
             start_append_sector = [
                 sector for sector in
                 file.sectors if sector.order == start_append_sector_order][0]
@@ -39,7 +36,7 @@ class CatAtCommand(BaseCommand):
             # Concatenating with the provided input at the
             # specified index
             start_append_sector_data = start_append_sector.data
-            start_index = index % sector_size()
+            start_index = index % SECTOR_SIZE
             text = start_append_sector_data[0:start_index] + \
                 text + start_append_sector_data[start_index:]
 
@@ -55,3 +52,48 @@ class CatAtCommand(BaseCommand):
             for sector in end_sectors:
                 end_order += 1
                 sector.order = end_order
+
+    def read_from_file(self, file, index, size):
+        file_size = FileDao.get_file_size(file)
+        if (index >= file_size):
+            raise ValueError(
+                'Index larger than content in file!')
+        # The sector from which data is to be read
+        start_read_sector_order = ceil((index + 1) / SECTOR_SIZE)
+        start_read_sector = [
+            sector for sector in
+            file.sectors if sector.order == start_read_sector_order][0]
+
+        # The remaining sectors to be read
+        end_sectors = [
+            sector for sector in file.sectors
+            if sector.order > start_read_sector_order
+        ]
+        # Sorting the remaining sectors by order
+        end_sectors.sort(key=lambda sector: sector.order)
+
+        # Read content of the sector from the specified index
+        start_read_sector_data = start_read_sector.data
+        start_index = index % SECTOR_SIZE
+        content = start_read_sector_data[start_index:]
+
+        # Read the content till the size specified
+        count = 0
+        while (size < len(content)) and (count < len(end_sectors)):
+            content += end_sectors[count].data
+            count += 1
+        return content[:size]
+
+    def run(self):
+        index = self.arguments[0].data
+        path = self.arguments[1].data
+        file = self.context.parse(path, True)
+
+        if self.options[0].exists:
+            text = self.get_input('Start Writing: ', prefix=False)
+            self.write_to_file(file, index, text)
+
+        else:
+            size = int(self.get_input('Total size to read:', prefix=False))
+            content = self.read_from_file(file, index, size)
+            self.log(content, prefix=False)

--- a/commands/cat_at.py
+++ b/commands/cat_at.py
@@ -9,7 +9,7 @@ from math import ceil
 
 class CatAtCommand(BaseCommand):
     command = 'cat-at'
-    arguments = [IntArgument(), StringArgument()]
+    arguments = [IntArgument(),  StringArgument()]
     options = [StringOption('-w')]
 
     def write_to_file(self, file, index, text):
@@ -51,7 +51,9 @@ class CatAtCommand(BaseCommand):
             end_order = last_append_sector_order
             for sector in end_sectors:
                 end_order += 1
-                sector.order = end_order
+                SectorDao.insert_sector_data(
+                    sector, data=sector.data,
+                    order=end_order, file_id=sector.file_id)
 
     def read_from_file(self, file, index, size):
         file_size = FileDao.get_file_size(file)

--- a/commands/fmap.py
+++ b/commands/fmap.py
@@ -7,27 +7,30 @@ class fmapCommand(BaseCommand):
 
     def run(self):
         files = FileDao.get_all_files()
-        format_string = '{:<38} {:<7} {:<23} {:<40} {:<8}'
-        # Printing the header
-        self.log('', prefix=False)
-        self.log(format_string.format(
-            'MemoryAddress', 'Bytes', 'Path',
-            'Sector Memory Address', 'Sector Order'), prefix=False)
-        self.log('', prefix=False)
+        if (len(files) != 0):
+            format_string = '{:<38} {:<7} {:<23} {:<40} {:<8}'
+            # Printing the header
+            self.log('', prefix=False)
+            self.log(format_string.format(
+                'MemoryAddress', 'Bytes', 'Path',
+                'Sector Memory Address', 'Sector Order'), prefix=False)
+            self.log('', prefix=False)
 
-        # Printing memory specs for all files
-        for file in files:
-            path = FileDao.get_path_of_file(file)
-            sectors = file.sectors
-            map = format_string.format(
-                file.id, FileDao.get_file_size(file),
-                path, '' if file.is_empty else sectors[0].id,
-                '' if file.is_empty else sectors[0].order)
-            self.log(map, prefix=False)
-            for sector in sectors:
-                if sector == sectors[0]:
-                    continue
-                self.log(format_string.format(
-                    '', '', '', str(sector.id), str(sector.order)),
-                    prefix=False)
-        self.log('', prefix=False)
+            # Printing memory specs for all files
+            for file in files:
+                path = FileDao.get_path_of_file(file)
+                sectors = file.sectors
+                map = format_string.format(
+                    file.id, FileDao.get_file_size(file),
+                    path, '' if file.is_empty else sectors[0].id,
+                    '' if file.is_empty else sectors[0].order)
+                self.log(map, prefix=False)
+                for sector in sectors:
+                    if sector == sectors[0]:
+                        continue
+                    self.log(format_string.format(
+                        '', '', '', str(sector.id), str(sector.order)),
+                        prefix=False)
+            self.log('', prefix=False)
+        else:
+            self.log('Memory is Empty!', prefix=False)

--- a/commands/fmap.py
+++ b/commands/fmap.py
@@ -2,7 +2,7 @@ from db.dao.file_dao import FileDao
 from base.command import BaseCommand
 
 
-class fmapCommand(BaseCommand):
+class FMapCommand(BaseCommand):
     command = 'fmap'
 
     def run(self):

--- a/commands/fmap.py
+++ b/commands/fmap.py
@@ -18,7 +18,7 @@ class FMapCommand(BaseCommand):
 
             # Printing memory specs for all files
             for file in files:
-                path = FileDao.get_path_of_file(file)
+                path = FileDao.get_path(file)
                 sectors = file.sectors
                 map = format_string.format(
                     file.id, FileDao.get_file_size(file),

--- a/commands/fmap.py
+++ b/commands/fmap.py
@@ -1,0 +1,33 @@
+from db.dao.file_dao import FileDao
+from base.command import BaseCommand
+
+
+class fmapCommand(BaseCommand):
+    command = 'fmap'
+
+    def run(self):
+        files = FileDao.get_all_files()
+        format_string = '{:<38} {:<7} {:<23} {:<40} {:<8}'
+        # Printing the header
+        self.log('', prefix=False)
+        self.log(format_string.format(
+            'MemoryAddress', 'Bytes', 'Path',
+            'Sector Memory Address', 'Sector Order'), prefix=False)
+        self.log('', prefix=False)
+
+        # Printing memory specs for all files
+        for file in files:
+            path = FileDao.get_path_of_file(file)
+            sectors = file.sectors
+            map = format_string.format(
+                file.id, FileDao.get_file_size(file),
+                path, '' if file.is_empty else sectors[0].id,
+                '' if file.is_empty else sectors[0].order)
+            self.log(map, prefix=False)
+            for sector in sectors:
+                if sector == sectors[0]:
+                    continue
+                self.log(format_string.format(
+                    '', '', '', str(sector.id), str(sector.order)),
+                    prefix=False)
+        self.log('', prefix=False)

--- a/commands/pwd.py
+++ b/commands/pwd.py
@@ -13,7 +13,6 @@ class PWDcommand(BaseCommand):
         restore = self.context.current_directory
 
         while (self.context.current_directory != root):
-
             parent = self.context.current_directory.directory
             str_parent = str(parent)
             path = '/'+str_parent+path

--- a/commands/pwd.py
+++ b/commands/pwd.py
@@ -1,5 +1,5 @@
+from db.dao.file_dao import FileDao
 from base.command import BaseCommand
-from db.dao.directory_dao import DirectoryDao
 
 
 class PWDcommand(BaseCommand):
@@ -7,15 +7,5 @@ class PWDcommand(BaseCommand):
     command = 'pwd'
 
     def run(self):
-        current = str(self.context.current_directory)
-        path = '/'+current
-        root = DirectoryDao.get_root_directory()
-        restore = self.context.current_directory
-
-        while (self.context.current_directory != root):
-            parent = self.context.current_directory.directory
-            str_parent = str(parent)
-            path = '/'+str_parent+path
-            self.context.current_directory = parent
-        self.context.current_directory = restore
+        path = FileDao.get_path(self)
         self.log(path)

--- a/db/base.py
+++ b/db/base.py
@@ -1,17 +1,11 @@
 from sqlalchemy.ext.declarative import declarative_base
 from uuid import uuid4
 
+TOTAL_SIZE = 200
+SECTOR_SIZE = 10
 
 Base = declarative_base()
 
 
 def uuid_str():
     return str(uuid4())
-
-
-def total_size():
-    return 200
-
-
-def sector_size():
-    return 10

--- a/db/dao/file_dao.py
+++ b/db/dao/file_dao.py
@@ -1,4 +1,4 @@
-from db.base import sector_size
+from db.base import SECTOR_SIZE
 from db.dao.sector_dao import SectorDao
 from db.db import DB
 from db.models.file import File
@@ -29,8 +29,8 @@ class FileDao:
         :param order: The preceding order number
         """
         divs = []
-        for cap in range(0, len(data), sector_size()):
-            divs.append(data[cap: cap + sector_size()])
+        for cap in range(0, len(data), SECTOR_SIZE):
+            divs.append(data[cap: cap + SECTOR_SIZE])
         if order is None:
             order = FileDao.get_highest_order_of_sectors(file)
         for div in divs:

--- a/db/dao/file_dao.py
+++ b/db/dao/file_dao.py
@@ -1,3 +1,5 @@
+from db.dao.directory_dao import DirectoryDao
+from db.models.directory import Directory
 from db.base import SECTOR_SIZE
 from db.dao.sector_dao import SectorDao
 from db.db import DB
@@ -114,6 +116,25 @@ class FileDao:
         """
         return not (bool(re.search(
             r'^[@!#$%^&+-=\.\/\\\*]|([\\\/]+)', filename)))
+
+    @staticmethod
+    def get_all_files():
+        return DB().session.query(File).all()
+
+    @staticmethod
+    def get_path_of_file(file):
+        current = DB().session.query(Directory).get(file.directory_id)
+        path = str(current)
+        root = DirectoryDao.get_root_directory()
+        restore = current
+        while (current != root):
+            parent = current.directory
+            str_parent = str(parent)
+            path = str_parent+'/'+path
+            current = parent
+        current = restore
+        path = path+'/'+file.name
+        return path
 
     @staticmethod
     def get_highest_order_of_sectors(file):

--- a/db/dao/file_dao.py
+++ b/db/dao/file_dao.py
@@ -123,8 +123,13 @@ class FileDao:
         return DB().session.query(File).all()
 
     @staticmethod
-    def get_path_of_file(file):
-        current = DB().session.query(Directory).get(file.directory_id)
+    def get_path(obj):
+        isFile = isinstance(obj, File)
+        if isFile:
+            current = DB().session.query(Directory).get(obj.directory_id)
+        else:
+            current = obj.context.current_directory
+
         path = str(current)
         root = DirectoryDao.get_root_directory()
         restore = current
@@ -134,7 +139,7 @@ class FileDao:
             path = str_parent+'/'+path
             current = parent
         current = restore
-        path = path+'/'+file.name
+        path = path+'/' + (obj.name if isFile else '')
         return path
 
     @staticmethod

--- a/db/dao/file_dao.py
+++ b/db/dao/file_dao.py
@@ -42,7 +42,7 @@ class FileDao:
             order += 1
             sector = SectorDao.get_first_unused_sector()
             SectorDao.insert_sector_data(
-                sector, div, order, True, file.id)
+                sector, div, order, file.id)
         return order
 
     @staticmethod
@@ -56,7 +56,6 @@ class FileDao:
         for sector in file.sectors:
             sector.data = None
             sector.order = 0
-            sector.is_used = False
             sector.file_id = None
         if commit:
             DB().session.commit()

--- a/db/dao/sector_dao.py
+++ b/db/dao/sector_dao.py
@@ -33,23 +33,21 @@ class SectorDao:
         """ Returns the first available sector
         """
         return DB().session.query(Sector).filter_by(
-            is_used=False
+            data=None
         ).first()
 
     @staticmethod
     def insert_sector_data(sector, data=None, order=0,
-                           is_used=False, file_id=None):
+                           file_id=None):
         """ Inserts the values in an already created sector
         record
         :param sector: Sector object model to be manipulated
         :param data: Specifies the data to be inserted
-        :param is_used: Specifies whether sector is empty
         :param file_id: Specifies the id of the file linked
         with this sector
         """
         sector.data = data
         sector.order = order
-        sector.is_used = is_used
         sector.file_id = file_id
         DB().session.commit()
 
@@ -69,7 +67,7 @@ class SectorDao:
         Returns the total count of available sectors
         """
         return len(DB().session.query(Sector).filter_by(
-            is_used=False
+            data=None
         ).all())
 
     @staticmethod

--- a/db/dao/sector_dao.py
+++ b/db/dao/sector_dao.py
@@ -34,7 +34,8 @@ class SectorDao:
         """
         return DB().session.query(Sector).filter_by(
             data=None
-        ).first()
+        ).union(DB().session.query(Sector).filter_by(data='')
+                ).first()
 
     @staticmethod
     def insert_sector_data(sector, data=None, order=0,
@@ -68,7 +69,8 @@ class SectorDao:
         """
         return len(DB().session.query(Sector).filter_by(
             data=None
-        ).all())
+        ).union(DB().session.query(Sector).filter_by(data='')
+                ).all())
 
     @staticmethod
     def is_memory_full():

--- a/db/models/sector.py
+++ b/db/models/sector.py
@@ -1,5 +1,4 @@
 from sqlalchemy import Column, String, Integer, ForeignKey
-from sqlalchemy.sql.sqltypes import Boolean
 
 from db.base import Base, uuid_str
 
@@ -12,7 +11,6 @@ class Sector(Base):
     id = Column(String, default=uuid_str, primary_key=True)
     data = Column(String)
     order = Column(Integer)
-    is_used = Column(Boolean, default=False)
     file_id = Column(String, ForeignKey('file.id'))
 
     def __repr__(self):

--- a/db/models/sector.py
+++ b/db/models/sector.py
@@ -14,4 +14,4 @@ class Sector(Base):
     file_id = Column(String, ForeignKey('file.id'))
 
     def __repr__(self):
-        return f'sector:{self.order}'
+        return f'sector:{self.id}'

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from commands.cat_at import CatAtCommand
 from commands.rm import RmCommand
 from commands.mv import MvCommand
 from commands.pwd import PWDcommand
-from commands.fmap import fmapCommand
+from commands.fmap import FMapCommand
 
 from db.db import DB
 
@@ -25,7 +25,7 @@ def main():
 
     terminal = BaseTerminal(commands=[
         PingCommand, CDCommand, MkDirCommand, LSCommand, PWDcommand,
-        TouchCommand, CatEndCommand, CatCommand, fmapCommand,
+        TouchCommand, CatEndCommand, CatCommand, FMapCommand,
         CatAtCommand, RmCommand, MvCommand])
     terminal.run()
 

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from commands.cat_at import CatAtCommand
 from commands.rm import RmCommand
 from commands.mv import MvCommand
 from commands.pwd import PWDcommand
+from commands.fmap import fmapCommand
 
 from db.db import DB
 
@@ -24,7 +25,7 @@ def main():
 
     terminal = BaseTerminal(commands=[
         PingCommand, CDCommand, MkDirCommand, LSCommand, PWDcommand,
-        TouchCommand, CatEndCommand, CatCommand,
+        TouchCommand, CatEndCommand, CatCommand, fmapCommand,
         CatAtCommand, RmCommand, MvCommand])
     terminal.run()
 


### PR DESCRIPTION
`cat <filename>`  -> reads entire content of the file
`cat -w <filename>` -> overwrites data on the file
`cat-at <index> <filename>` -> reads content starting at specified index with a specific size [Taken as input separately]
`cat-at -w <index> <filename>` -> appends content at the specified index
`fmap` -> displays the memory map

CHANGE:
- Removed is_used column in sector db
- Introduced global variables for sector size and memory size
close #40 #42 #43 #44 